### PR TITLE
fix(types): Simply types of commit

### DIFF
--- a/types.json
+++ b/types.json
@@ -9,7 +9,7 @@
     "description": "Documentation only changes"
   },
   "style": {
-    "description": "Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)"
+    "description": "Style changes (e.g. whitespace, formatting, missing semi-colon, etc)"
   },
   "refactor": {
     "description": "A code change that neither fixes a bug nor adds a feature"
@@ -21,10 +21,10 @@
     "description": "Adding missing tests or correcting existing tests"
   },
   "build": {
-    "description": "Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)"
+    "description": "Build system or external dependency change (e.g. gulp, npm, etc)"
   },
   "ci": {
-    "description": "Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)"
+    "description": "CI config file and script changes (e.g. Travis, Circle, etc)"
   },
   "chore": {
     "description": "Other changes that don't modify src or test files"


### PR DESCRIPTION
This commit simplifies and shortens the descriptions for the choice of
types of commits

Feedback welcome on changes on descriptions or comments if deemed unnecessary.