### PR TITLE
docs(README): Add install and usage notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,44 @@ Status:
 
 A plugin for [commitizen](https://github.com/commitizen/cz-cli) built for
 freeCodeCamp
+
+**Table of Contents**
+
+- [Introduction](#introduction)
+- [Local Installation](#local-installation)
+- [Usage](#usage)
+
+# Introduction
+
+This Commitizen adapter helps standardize commit messages for freeCodeCamp so
+being asked to fix incorrectly formatted commit messages will be less of a
+problem.
+
+# Local Installation
+
+```shell
+# Install general tool globally
+npm install -g commitizen
+
+# Install freeCodeCamp specific adapter
+git clone https://github.com/freeCodeCamp/cz-freecodecamp.git
+
+# Add freeCodeCamp plugin to be used
+cd cz-freecodecamp
+echo '{ "path": "'$(pwd)'" }' > ~/.czrc
+
+# Install node modules for adapter
+npm install
+```
+
+# Usage
+
+```shell
+... # Make changes
+
+# Stage changes
+git add changed-file
+
+# Use git cz instead of git commit
+git cz
+```


### PR DESCRIPTION
Add notes on how to use the adapter. Feel free to give comments on making the instructions better.

The installation instructions will be temporary until cz-freecodecamp is up on npm, which can be changed in the future. If there's a better way to install this adapter, let me know and I can update the instructions.