### PR TITLE
fix(index): Prevent stand-alone numbers in title

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ module.exports = {
           Write a short, imperative tense description of the change (no issue numbers)\n  E.g. Change loop challenge format:
         `,
         validate: function(input) {
-          const noIssueNumbers = /#?\d+/g;
+          const noIssueNumbers = /\s#?\d+\s?/g;
           return !noIssueNumbers.test(input);
         },
         filter: function(input) {


### PR DESCRIPTION
The previous regex flagged a false positive with "es6" being in a title.
This commit makes the specification more specific in that numbers
standing alone with or without an hash symbol (#) cannot be used when
flanked by white space.

Closes #18